### PR TITLE
Add unicode operators, top level functions, ado

### DIFF
--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -69,7 +69,7 @@
       (my-types-modules-regexp "\\<[A-Z][0-9A-Za-z_']*")
       (my-function-names-regexp "^\\([a-z_][0-9A-Za-z_']*\\|([^)]+)\\)")
       )
-   `((,my-operators-regexp . font-lock-highlighting-faces)
+   `((,my-operators-regexp . font-lock-operator-face)
      (,my-keywords-regexp . font-lock-keyword-face)
      (,my-types-modules-regexp . font-lock-type-face)
      (,my-function-names-regexp . font-lock-function-name-face)

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -51,7 +51,7 @@
      ((my-keywords-regexp
        (regexp-opt
         '("if" "then" "else" "case" "of"
-          "ado" "do" "_" "let"
+          "ado" "do" "_" "let" "foreign"
           "module" "import" "where" "as"
           "instance" "derive" "forall" "∀"
           "newtype" "data" "class" "type" "kind"

--- a/purescript-mode.el
+++ b/purescript-mode.el
@@ -51,21 +51,28 @@
      ((my-keywords-regexp
        (regexp-opt
         '("if" "then" "else" "case" "of"
-          "do" "_" "let"
-          "module" "import" "where" "as" "foreign"
-          "instance" "derive" "forall"
+          "ado" "do" "_" "let"
+          "module" "import" "where" "as"
+          "instance" "derive" "forall" "∀"
           "newtype" "data" "class" "type" "kind"
           "infix" "infixl" "infixr")
         'words))
       (my-operators-regexp
        (regexp-opt
-        '("::" "=>" "->" "<-" "<=" "~>" "|")
+        '("::" "∷"
+          "=>" "⇒"
+          "->" "→"
+          "<-" "←"
+          "<=" "⇐"
+          "~>" "|")
         'words))
       (my-types-modules-regexp "\\<[A-Z][0-9A-Za-z_']*")
+      (my-function-names-regexp "^\\([a-z_][0-9A-Za-z_']*\\|([^)]+)\\)")
       )
-   `((,my-operators-regexp . font-lock-operator-face)
+   `((,my-operators-regexp . font-lock-highlighting-faces)
      (,my-keywords-regexp . font-lock-keyword-face)
      (,my-types-modules-regexp . font-lock-type-face)
+     (,my-function-names-regexp . font-lock-function-name-face)
      )))
 
 (defcustom purescript-mode-hook nil


### PR DESCRIPTION
The top level functions are stolen from Elm mode.